### PR TITLE
readme: add travis-cli build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Up To Date
+# Up To Date [![Build Status](https://travis-ci.org/elastic/uptd.svg?branch=master)](https://travis-ci.org/elastic/uptd)
 
 `uptd` (shorthand for _up to date_) is a Go package which provides primitives
 and mechanisms to check if a version is up to date according to the latest one


### PR DESCRIPTION
## Description

This change adds the Travis CI badge to the main `README.md` file.