### PR TITLE
github: Fix incorrect Latest signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ unit:
 
 .PHONY: tag
 tag:
-	@ git tag $(VERSION)
+	@ git tag $(VERSION)
 
 .PHONY: release
 release:
-	@ git push upstream $(VERSION)
+	@ git push upstream $(VERSION)

--- a/github.go
+++ b/github.go
@@ -25,6 +25,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var _ Provider = new(GithubProvider)
+
 // GetLatestFunc is used by the GithubProvider to discover newer releases
 type GetLatestFunc func(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)
 
@@ -55,18 +57,18 @@ func NewGithubProvider(owner, repo, token string) (*GithubProvider, error) {
 
 // Latest queries the remote Github repository to check for a newer version of
 // the executable available.
-func (u *GithubProvider) Latest() (*LatestResponse, error) {
+func (u *GithubProvider) Latest() (LatestResponse, error) {
 	release, _, err := u.latestFunc(context.Background(), u.owner, u.repo)
 	if err != nil {
-		return nil, err
+		return LatestResponse{}, err
 	}
 
 	version, err := semver.Parse(release.GetName())
 	if err != nil {
-		return nil, err
+		return LatestResponse{}, err
 	}
 
-	return &LatestResponse{
+	return LatestResponse{
 		Version:    version,
 		URL:        release.GetHTMLURL(),
 		PreRelease: release.GetPrerelease() || release.GetDraft(),

--- a/github_test.go
+++ b/github_test.go
@@ -56,7 +56,6 @@ func TestNewGithubProvider(t *testing.T) {
 			args: args{
 				owner: "anowner",
 				repo:  "arepo",
-				// token: "",
 			},
 			want:    nil,
 			wantErr: true,
@@ -99,7 +98,7 @@ func TestGithubProviderLatest(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    *LatestResponse
+		want    LatestResponse
 		wantErr bool
 	}{
 		{
@@ -110,7 +109,7 @@ func TestGithubProviderLatest(t *testing.T) {
 					HTMLURL: newStringP("https://host/path/version"),
 				}, nil, nil),
 			},
-			want: &LatestResponse{
+			want: LatestResponse{
 				Version:    newSemver("99.99.99"),
 				URL:        "https://host/path/version",
 				PreRelease: false,
@@ -126,7 +125,7 @@ func TestGithubProviderLatest(t *testing.T) {
 					Draft:   newBoolP(true),
 				}, nil, nil),
 			},
-			want: &LatestResponse{
+			want: LatestResponse{
 				Version:    newSemver("99.99.99"),
 				URL:        "https://host/path/version",
 				PreRelease: true,
@@ -142,7 +141,7 @@ func TestGithubProviderLatest(t *testing.T) {
 					Prerelease: newBoolP(true),
 				}, nil, nil),
 			},
-			want: &LatestResponse{
+			want: LatestResponse{
 				Version:    newSemver("99.99.99"),
 				URL:        "https://host/path/version",
 				PreRelease: true,
@@ -156,7 +155,6 @@ func TestGithubProviderLatest(t *testing.T) {
 					Name: newStringP("WHATISTHISVERSION"),
 				}, nil, nil),
 			},
-			want:    nil,
 			wantErr: true,
 		},
 		{
@@ -164,7 +162,6 @@ func TestGithubProviderLatest(t *testing.T) {
 			fields: fields{
 				latestFunc: newLatestMockFunc(nil, nil, errors.New("ERROR")),
 			},
-			want:    nil,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
## Description

This change fixes the incorrect Latest signature for GithubProvider.
Also ensures that GithubProvider implements the Provider interface.