### PR TITLE
fix: `Latest` uses Tag name and strip "v" prefix

### DIFF
--- a/github.go
+++ b/github.go
@@ -19,6 +19,7 @@ package uptd
 
 import (
 	"context"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/github"
@@ -63,7 +64,7 @@ func (u *GithubProvider) Latest() (LatestResponse, error) {
 		return LatestResponse{}, err
 	}
 
-	version, err := semver.Parse(release.GetName())
+	version, err := semver.Parse(strings.TrimPrefix(release.GetTagName(), "v"))
 	if err != nil {
 		return LatestResponse{}, err
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -105,7 +105,22 @@ func TestGithubProviderLatest(t *testing.T) {
 			name: "Latest() call succeeds",
 			fields: fields{
 				latestFunc: newLatestMockFunc(&github.RepositoryRelease{
-					Name:    newStringP("99.99.99"),
+					TagName: newStringP("99.99.99"),
+					HTMLURL: newStringP("https://host/path/version"),
+				}, nil, nil),
+			},
+			want: LatestResponse{
+				Version:    newSemver("99.99.99"),
+				URL:        "https://host/path/version",
+				PreRelease: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Latest() call succeeds when the release name has a v prefix",
+			fields: fields{
+				latestFunc: newLatestMockFunc(&github.RepositoryRelease{
+					TagName: newStringP("v99.99.99"),
 					HTMLURL: newStringP("https://host/path/version"),
 				}, nil, nil),
 			},
@@ -120,7 +135,7 @@ func TestGithubProviderLatest(t *testing.T) {
 			name: "Latest() call succeeds with Prerelease true",
 			fields: fields{
 				latestFunc: newLatestMockFunc(&github.RepositoryRelease{
-					Name:    newStringP("99.99.99"),
+					TagName: newStringP("99.99.99"),
 					HTMLURL: newStringP("https://host/path/version"),
 					Draft:   newBoolP(true),
 				}, nil, nil),
@@ -136,7 +151,7 @@ func TestGithubProviderLatest(t *testing.T) {
 			name: "Latest() call succeeds with Prerelease true",
 			fields: fields{
 				latestFunc: newLatestMockFunc(&github.RepositoryRelease{
-					Name:       newStringP("99.99.99"),
+					TagName:    newStringP("99.99.99"),
 					HTMLURL:    newStringP("https://host/path/version"),
 					Prerelease: newBoolP(true),
 				}, nil, nil),
@@ -152,7 +167,7 @@ func TestGithubProviderLatest(t *testing.T) {
 			name: "Latest() call fails due wrong semver version",
 			fields: fields{
 				latestFunc: newLatestMockFunc(&github.RepositoryRelease{
-					Name: newStringP("WHATISTHISVERSION"),
+					TagName: newStringP("WHATISTHISVERSION"),
 				}, nil, nil),
 			},
 			wantErr: true,

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/elastic/uptd
 
+go 1.13
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -11,6 +12,8 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1 h1:VeAkjQVzKLmu+JnFcK96TPbkuaTIqwGGAzQ9hgwPjVg=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
## Description
Modifies the GitHub provider to use the github Tag name instead of the
release name. Additionally, `Latest()` now removes the "v" prefix from
the tag version if found.